### PR TITLE
fix: patch remaining Dependabot security alerts (js-cookie, brace-expansion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@supabase/supabase-js": "^2.103.0",
     "canvas-confetti": "^1.9.4",
     "cookies": "^0.9.1",
-    "js-cookie": "^3.0.5",
+    "js-cookie": "^3.0.7",
     "moment": "^2.29.4",
     "next": "^16.2.6",
     "react": "19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,11 +3346,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4575,7 +4575,7 @@ __metadata:
     eslint-import-resolver-node: "npm:^0.3.9"
     eslint-import-resolver-typescript: "npm:^3.6.3"
     eslint-plugin-check-file: "npm:^2.8.0"
-    js-cookie: "npm:^3.0.5"
+    js-cookie: "npm:^3.0.7"
     jsdom: "npm:^29.0.2"
     moment: "npm:^2.29.4"
     next: "npm:^16.2.6"
@@ -5725,10 +5725,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "js-cookie@npm:3.0.5"
-  checksum: 10c0/04a0e560407b4489daac3a63e231d35f4e86f78bff9d792011391b49c59f721b513411cd75714c418049c8dc9750b20fcddad1ca5a2ca616c3aca4874cce5b3a
+"js-cookie@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "js-cookie@npm:3.0.7"
+  checksum: 10c0/c921c43014e98bb94a1765663a1a10d693048d61444e374c1ecf459eba92320381f9c406e724df9aa44e819c4b606e6a7240f2abe2d5c54ad1e73a3002b191c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves the two open Dependabot alerts on `master`. (`next` 16.2.6 and `postcss` 8.5.15 were already patched on master.)

| Package | Bump | Severity | Advisory |
|---|---|---|---|
| `js-cookie` | 3.0.5 → 3.0.7 | high | GHSA-qjx8-664m-686j — prototype hijack / cookie-attribute injection |
| `brace-expansion` (transitive) | 5.0.5 → 5.0.6 | medium | within-range lockfile refresh; 1.x/2.x lines unaffected |

**Verification:** `yarn npm audit` clean (low+), `yarn type-check` passes, 91/91 tests pass.

No source changes — `package.json` (js-cookie pin) and `yarn.lock` only.