### PR TITLE
fix: cache highscores with ISR + optimistic player row

### DIFF
--- a/docs/why-the-app-is-sometimes-unavailable.html
+++ b/docs/why-the-app-is-sometimes-unavailable.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Why Eureka is sometimes hard to reach</title>
+<style>
+  :root{
+    --ink:#1a1c2e; --muted:#5b5f76; --line:#e7e8f0; --bg:#f6f7fb;
+    --green:#1f8a55; --green-bg:#e7f6ee; --amber:#9a6b00; --amber-bg:#fdf3dd;
+    --blue:#2b56d4; --blue-bg:#eaf0ff; --card:#ffffff;
+  }
+  *{box-sizing:border-box}
+  html{ -webkit-text-size-adjust:100% }
+  body{
+    margin:0; background:var(--bg); color:var(--ink);
+    font:17px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  }
+  .wrap{ max-width:780px; margin:0 auto; padding:40px 22px 80px }
+  header.hero{
+    background:linear-gradient(135deg,#2b56d4,#6a3fd0); color:#fff;
+    border-radius:20px; padding:34px 32px; margin-bottom:30px;
+    box-shadow:0 12px 30px rgba(43,86,212,.22);
+  }
+  header.hero .eyebrow{ text-transform:uppercase; letter-spacing:.12em; font-size:12.5px; opacity:.85; margin:0 0 10px }
+  header.hero h1{ margin:0 0 12px; font-size:30px; line-height:1.2; font-weight:700 }
+  header.hero p{ margin:0; font-size:17px; opacity:.95 }
+  header.hero .date{ margin-top:18px; font-size:13px; opacity:.8 }
+
+  .tldr{
+    background:var(--card); border:1px solid var(--line); border-left:5px solid var(--blue);
+    border-radius:14px; padding:22px 24px; margin-bottom:30px;
+  }
+  .tldr h2{ margin:0 0 8px; font-size:15px; text-transform:uppercase; letter-spacing:.08em; color:var(--blue) }
+  .tldr p{ margin:0; font-size:18px }
+  .tldr strong{ color:var(--ink) }
+
+  h2.section{ font-size:21px; margin:38px 0 14px }
+  p{ color:var(--ink) }
+  .lead{ color:var(--muted) }
+
+  .pills{ display:flex; flex-wrap:wrap; gap:10px; margin:8px 0 4px }
+  .pill{ font-size:13.5px; font-weight:600; padding:6px 12px; border-radius:999px; display:inline-flex; gap:7px; align-items:center }
+  .pill.ok{ background:var(--green-bg); color:var(--green) }
+  .pill.warn{ background:var(--amber-bg); color:var(--amber) }
+  .dot{ width:8px;height:8px;border-radius:50% }
+  .dot.ok{ background:var(--green) } .dot.warn{ background:var(--amber) }
+
+  table.checks{ width:100%; border-collapse:collapse; background:var(--card);
+    border:1px solid var(--line); border-radius:14px; overflow:hidden; margin:10px 0 6px; font-size:15.5px }
+  table.checks th, table.checks td{ text-align:left; padding:13px 16px; vertical-align:top; border-bottom:1px solid var(--line) }
+  table.checks th{ background:#fafbff; font-size:13px; text-transform:uppercase; letter-spacing:.05em; color:var(--muted) }
+  table.checks tr:last-child td{ border-bottom:none }
+  table.checks .verdict{ white-space:nowrap; font-weight:600 }
+  table.checks .verdict.ok{ color:var(--green) }
+  table.checks .verdict.warn{ color:var(--amber) }
+
+  .analogy{ background:#fff; border:1px solid var(--line); border-radius:16px; padding:24px 26px; margin:14px 0 }
+  .analogy h3{ margin:0 0 10px; font-size:18px }
+  .analogy .shop{ display:flex; gap:16px; flex-wrap:wrap; margin-top:16px }
+  .analogy .shop .box{ flex:1 1 220px; background:var(--bg); border-radius:12px; padding:16px 18px }
+  .analogy .shop .box .ic{ font-size:24px }
+  .analogy .shop .box b{ display:block; margin:6px 0 4px }
+  .analogy .shop .box span{ color:var(--muted); font-size:14.5px }
+
+  .callout{ border-radius:14px; padding:18px 22px; margin:18px 0; font-size:16px }
+  .callout.amber{ background:var(--amber-bg); border:1px solid #f0dca6 }
+  .callout.amber b{ color:var(--amber) }
+
+  ol.recs{ counter-reset:r; list-style:none; padding:0; margin:10px 0 }
+  ol.recs li{ counter-increment:r; background:var(--card); border:1px solid var(--line);
+    border-radius:14px; padding:16px 18px 16px 58px; position:relative; margin-bottom:12px }
+  ol.recs li::before{ content:counter(r); position:absolute; left:16px; top:16px;
+    width:28px;height:28px; border-radius:50%; background:var(--blue); color:#fff;
+    font-weight:700; font-size:15px; display:flex; align-items:center; justify-content:center }
+  ol.recs li b{ display:block; margin-bottom:3px }
+  ol.recs li span{ color:var(--muted); font-size:15px }
+
+  footer{ margin-top:42px; padding-top:20px; border-top:1px solid var(--line); color:var(--muted); font-size:13.5px }
+  .glossary{ margin-top:8px }
+  .glossary details{ background:var(--card); border:1px solid var(--line); border-radius:10px; padding:4px 16px; margin-bottom:8px }
+  .glossary summary{ cursor:pointer; font-weight:600; padding:10px 0 }
+  .glossary p{ margin:0 0 12px; color:var(--muted); font-size:15px }
+
+  @media print{ body{ background:#fff } header.hero{ box-shadow:none } .wrap{ padding-top:0 } }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="hero">
+    <p class="eyebrow">Eureka · Service health explained</p>
+    <h1>Why the game is sometimes hard to reach</h1>
+    <p>A plain-language summary of what we looked into, what we found, and what we plan to do about it.</p>
+    <p class="date">Prepared 24 May 2026</p>
+  </header>
+
+  <div class="tldr">
+    <h2>The short version</h2>
+    <p>The game and all of its saved data are <strong>healthy — no faults found</strong>. The website is online right now, and every page loads. The likely reason some people occasionally can't reach it is that <strong>one page (the high-scores leaderboard) is built fresh on every visit and is slow</strong>. Pages built this way can briefly "fall asleep" when traffic is quiet, and waking them up sometimes takes long enough to fail. We have a clear, low-risk fix.</p>
+  </div>
+
+  <h2 class="section">Where we looked</h2>
+  <p class="lead">Think of the app as having three separate parts. We inspected the records (the "logs") for each one.</p>
+
+  <table class="checks">
+    <thead>
+      <tr><th>The part we checked</th><th>In everyday terms</th><th>What we found</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><b>The data store</b></td>
+        <td>The storeroom where every game and score is kept.</td>
+        <td class="verdict ok">Healthy ✓</td>
+      </tr>
+      <tr>
+        <td><b>Error monitoring</b></td>
+        <td>A brand-new "smoke alarm" that reports problems the moment they happen.</td>
+        <td class="verdict ok">Active, quiet ✓</td>
+      </tr>
+      <tr>
+        <td><b>The website host</b></td>
+        <td>The service that delivers each page to visitors.</td>
+        <td class="verdict warn">Online, but one slow page ⚠</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="pills">
+    <span class="pill ok"><span class="dot ok"></span> Storeroom: zero errors in 24 hours</span>
+    <span class="pill ok"><span class="dot ok"></span> Smoke alarm: no real alerts yet</span>
+    <span class="pill warn"><span class="dot warn"></span> Leaderboard page: ~2.5 seconds to load</span>
+  </div>
+
+  <h2 class="section">What we found</h2>
+  <p>The storeroom is in perfect shape — every request to it succeeded, and looking up the top-10 scores takes a fraction of a millisecond. So <b>the data is not the problem</b>.</p>
+  <p>The website is online. Most pages are <b>pre-made</b>, so they appear almost instantly. But the <b>high-scores leaderboard is rebuilt from scratch every single time someone opens it</b>, and that consistently takes about <b>2.5 seconds</b> — while every other page responds in well under half a second. The delay isn't the data (that part is instant); it's the act of assembling that one page on demand.</p>
+
+  <div class="analogy">
+    <h3>An everyday way to picture it</h3>
+    <p>Imagine the game is a shop:</p>
+    <div class="shop">
+      <div class="box">
+        <div class="ic">📦</div>
+        <b>The storeroom</b>
+        <span>Fully stocked and well-organised. Staff find anything instantly. (This is working perfectly.)</span>
+      </div>
+      <div class="box">
+        <div class="ic">📄</div>
+        <b>Most pages</b>
+        <span>Pre-printed flyers by the door — handed out the instant you walk in.</span>
+      </div>
+      <div class="box">
+        <div class="ic">✍️</div>
+        <b>The leaderboard</b>
+        <span>Hand-written fresh for each visitor by a staff member who, when the shop is quiet, has gone to the back and needs a moment to return.</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout amber">
+    <b>Why it's "sometimes," not "always":</b> when very few people are visiting, the part of the system that builds that page <b>goes to sleep to save resources</b>. The next visitor has to wait for it to wake up. Usually that's just a slow load — but occasionally the wake-up takes long enough that the visitor gets an error instead of the page. Because it depends on the exact timing of visits, it happens <b>unpredictably</b>, which is why it's been so hard to catch.
+  </div>
+
+  <p>Importantly, these hiccups don't register as "errors" in the traditional sense — the system isn't breaking, it's just being too slow in that one spot. That's exactly why earlier checks came back clean and the cause stayed hidden.</p>
+
+  <h2 class="section">What we recommend</h2>
+  <ol class="recs">
+    <li>
+      <b>Pre-make the leaderboard and refresh it automatically</b>
+      <span>Instead of rebuilding it for every visitor, keep a ready-made copy and refresh it every 30 seconds. It becomes instant and can no longer "fall asleep" or time out. This is the main fix, and it's low-risk.</span>
+    </li>
+    <li>
+      <b>Keep a longer record of front-door traffic</b>
+      <span>Today the host only keeps about an hour of delivery records, so a hiccup is often gone before anyone can look. Extending this means the next occurrence is captured with evidence.</span>
+    </li>
+    <li>
+      <b>Let the new monitoring keep watch</b>
+      <span>The "smoke alarm" we just installed will now flag genuine faults the instant they occur — including a specific configuration slip we want to rule out. No action needed; it simply needs to run.</span>
+    </li>
+  </ol>
+
+  <footer>
+    <p><b>Bottom line:</b> nothing is broken in the game or its data. The intermittent trouble points to one slow, on-demand page that can stall when traffic is light. The recommended fix is straightforward and removes that exposure.</p>
+
+    <div class="glossary">
+      <details>
+        <summary>A few terms, in plain English</summary>
+        <p><b>Pre-made / pre-printed page:</b> a page prepared in advance so it can be shown instantly, the same way to everyone.</p>
+        <p><b>Built on demand:</b> a page assembled freshly each time someone asks for it — more flexible, but slower, and able to "fall asleep" when idle.</p>
+        <p><b>Falling asleep (cold start):</b> to save money and energy, parts of the system that aren't being used pause themselves. The first visitor afterwards has to wait for them to wake up.</p>
+        <p><b>Error monitoring:</b> a tool that automatically reports problems as they happen, so we don't have to wait for someone to notice and complain.</p>
+      </details>
+    </div>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/src/app/highscores/page.tsx
+++ b/src/app/highscores/page.tsx
@@ -1,12 +1,12 @@
 import getHighscores from "@/db/select-game";
+import Leaderboard from "@/components/leaderboard";
 
-export const dynamic = "force-dynamic";
-
-const MEDALS: Record<number, { emoji: string; row: string; score: string }> = {
-  1: { emoji: "🥇", row: "bg-yellow-900/40 border-l-4 border-yellow-400", score: "text-yellow-300" },
-  2: { emoji: "🥈", row: "bg-slate-700/60 border-l-4 border-slate-400", score: "text-slate-300" },
-  3: { emoji: "🥉", row: "bg-orange-900/30 border-l-4 border-orange-400", score: "text-orange-300" },
-};
+// ISR: serve a pre-rendered leaderboard and refresh it at most once every 30s.
+// A top-10 all-time board tolerates slight staleness, and this avoids the
+// ~2.5s per-request render (and cold-start timeouts) that made the page feel
+// "unavailable". On a DB hiccup, Next keeps serving the last good page rather
+// than erroring — strictly more resilient than rendering live on every request.
+export const revalidate = 30;
 
 const HighscoresController = async () => {
   const highscores = await getHighscores();
@@ -21,48 +21,10 @@ const HighscoresController = async () => {
         <p className="text-slate-400 mt-1 text-xs sm:text-sm tracking-wide">Top 10 all-time players</p>
       </div>
 
-      {/* Table card — grows to fill remaining height */}
-      <div className="w-full sm:w-[80vw] rounded-2xl overflow-hidden shadow-2xl border border-slate-600 flex flex-col flex-1 min-h-0">
-        {/* Table header */}
-        <div className="grid grid-cols-[2.5rem_1fr_5rem_4rem] sm:grid-cols-[5rem_1fr_10rem_8rem] bg-slate-900 text-slate-400 uppercase text-xs sm:text-sm font-bold tracking-widest px-3 sm:px-6 py-3 sm:py-4 shrink-0">
-          <span className="text-center">#</span>
-          <span>Player</span>
-          <span className="text-right">Score</span>
-          <span className="text-right">Level</span>
-        </div>
-
-        {/* Rows — fill remaining space, scroll if needed */}
-        <div className="flex flex-col flex-1 overflow-y-auto">
-          {highscores.length === 0 ? (
-            <div className="flex-1 flex items-center justify-center bg-slate-700 text-slate-400 italic text-base sm:text-lg">
-              No scores yet — be the first to play!
-            </div>
-          ) : (
-            highscores.map((entry) => {
-              const medal = MEDALS[entry.rank];
-              return (
-                <div
-                  key={entry.id}
-                  className={`grid grid-cols-[2.5rem_1fr_5rem_4rem] sm:grid-cols-[5rem_1fr_10rem_8rem] items-center px-3 sm:px-6 flex-1 text-sm sm:text-base border-b border-slate-600/50 last:border-b-0 ${
-                    medal ? medal.row : "bg-slate-700/40"
-                  }`}
-                >
-                  <span className="text-center text-2xl sm:text-5xl">
-                    {medal ? medal.emoji : <span className="text-slate-500 text-xl sm:text-3xl font-bold">{entry.rank}</span>}
-                  </span>
-                  <span className="text-white font-medium truncate pr-2 text-sm sm:text-lg">
-                    {entry.name || <span className="text-slate-500 italic">Anonymous</span>}
-                  </span>
-                  <span className={`text-right font-bold tabular-nums text-sm sm:text-lg ${medal ? medal.score : "text-white"}`}>
-                    {entry.score}
-                  </span>
-                  <span className="text-right text-slate-400 tabular-nums text-sm sm:text-lg">{entry.level}</span>
-                </div>
-              );
-            })
-          )}
-        </div>
-      </div>
+      {/* Leaderboard (client component): renders the cached server data and
+          optimistically merges the player's just-finished score so it appears
+          immediately, before the 30s ISR cache refreshes. */}
+      <Leaderboard initial={highscores} />
     </div>
   );
 };

--- a/src/components/leaderboard/index.tsx
+++ b/src/components/leaderboard/index.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useMemo } from "react";
+import { useGameStore } from "@/zustand/game-store";
+
+export interface HighscoreRow {
+  id: string;
+  name: string;
+  score: number;
+  level: number;
+  created_at: string;
+  rank: number;
+}
+
+const LIMIT = 10;
+
+const MEDALS: Record<number, { emoji: string; row: string; score: string }> = {
+  1: { emoji: "🥇", row: "bg-yellow-900/40 border-l-4 border-yellow-400", score: "text-yellow-300" },
+  2: { emoji: "🥈", row: "bg-slate-700/60 border-l-4 border-slate-400", score: "text-slate-300" },
+  3: { emoji: "🥉", row: "bg-orange-900/30 border-l-4 border-orange-400", score: "text-orange-300" },
+};
+
+interface LeaderboardProps {
+  /** Server-rendered top-10, revalidated by ISR every 30s. */
+  initial: HighscoreRow[];
+}
+
+const Leaderboard = ({ initial }: LeaderboardProps) => {
+  // The player's just-finished game stays in the store until they start a new
+  // one (endGame() leaves score/level/gameId/name intact). We optimistically
+  // merge it into the cached top-10 so a fresh high score shows up immediately,
+  // before the ISR cache (refreshed every 30s) catches up. Purely presentational
+  // and self-correcting: once the server list includes them, we dedupe by id.
+  const gameId = useGameStore((s) => s.gameId);
+  const name = useGameStore((s) => s.name);
+  const score = useGameStore((s) => s.score);
+  const level = useGameStore((s) => s.level);
+
+  const { rows, youId } = useMemo(() => {
+    const merged: Omit<HighscoreRow, "rank">[] = initial.map((r) => ({
+      id: r.id,
+      name: r.name,
+      score: r.score,
+      level: r.level,
+      created_at: r.created_at,
+    }));
+
+    let you: string | null = null;
+    if (gameId && score > 0) {
+      you = gameId;
+      if (!merged.some((r) => r.id === gameId)) {
+        merged.push({ id: gameId, name, score, level, created_at: new Date().toISOString() });
+      }
+    }
+
+    // Mirror the server ordering: score desc, then most recent first.
+    const ranked: HighscoreRow[] = merged
+      .sort((a, b) => b.score - a.score || b.created_at.localeCompare(a.created_at))
+      .slice(0, LIMIT)
+      .map((r, i) => ({ ...r, rank: i + 1 }));
+
+    // If the optimistic entry didn't crack the top 10, don't highlight anything.
+    if (you && !ranked.some((r) => r.id === you)) you = null;
+
+    return { rows: ranked, youId: you };
+  }, [initial, gameId, name, score, level]);
+
+  return (
+    <div className="w-full sm:w-[80vw] rounded-2xl overflow-hidden shadow-2xl border border-slate-600 flex flex-col flex-1 min-h-0">
+      {/* Table header */}
+      <div className="grid grid-cols-[2.5rem_1fr_5rem_4rem] sm:grid-cols-[5rem_1fr_10rem_8rem] bg-slate-900 text-slate-400 uppercase text-xs sm:text-sm font-bold tracking-widest px-3 sm:px-6 py-3 sm:py-4 shrink-0">
+        <span className="text-center">#</span>
+        <span>Player</span>
+        <span className="text-right">Score</span>
+        <span className="text-right">Level</span>
+      </div>
+
+      {/* Rows — fill remaining space, scroll if needed */}
+      <div className="flex flex-col flex-1 overflow-y-auto">
+        {rows.length === 0 ? (
+          <div className="flex-1 flex items-center justify-center bg-slate-700 text-slate-400 italic text-base sm:text-lg">
+            No scores yet — be the first to play!
+          </div>
+        ) : (
+          rows.map((entry) => {
+            const medal = MEDALS[entry.rank];
+            const isYou = entry.id === youId;
+            return (
+              <div
+                key={entry.id}
+                className={`grid grid-cols-[2.5rem_1fr_5rem_4rem] sm:grid-cols-[5rem_1fr_10rem_8rem] items-center px-3 sm:px-6 flex-1 text-sm sm:text-base border-b border-slate-600/50 last:border-b-0 ${
+                  medal ? medal.row : "bg-slate-700/40"
+                } ${isYou ? "ring-2 ring-inset ring-cyan-400/80" : ""}`}
+              >
+                <span className="text-center text-2xl sm:text-5xl">
+                  {medal ? (
+                    medal.emoji
+                  ) : (
+                    <span className="text-slate-500 text-xl sm:text-3xl font-bold">{entry.rank}</span>
+                  )}
+                </span>
+                <span className="flex items-center gap-2 min-w-0 pr-2">
+                  <span className="text-white font-medium truncate text-sm sm:text-lg">
+                    {entry.name || <span className="text-slate-500 italic">Anonymous</span>}
+                  </span>
+                  {isYou && (
+                    <span className="shrink-0 rounded-full bg-cyan-400/90 text-slate-900 text-[10px] sm:text-xs font-bold px-2 py-0.5 uppercase tracking-wide">
+                      You
+                    </span>
+                  )}
+                </span>
+                <span
+                  className={`text-right font-bold tabular-nums text-sm sm:text-lg ${
+                    medal ? medal.score : "text-white"
+                  }`}
+                >
+                  {entry.score}
+                </span>
+                <span className="text-right text-slate-400 tabular-nums text-sm sm:text-lg">
+                  {entry.level}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Leaderboard;

--- a/src/components/leaderboard/leaderboard.test.tsx
+++ b/src/components/leaderboard/leaderboard.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useGameStore } from "@/zustand/game-store";
+import Leaderboard, { type HighscoreRow } from "./index";
+
+vi.mock("@/zustand/game-store", () => ({
+  useGameStore: vi.fn(),
+}));
+
+const mockedUseGameStore = useGameStore as unknown as ReturnType<typeof vi.fn>;
+
+type StorePart = { gameId: string | null; name: string; score: number; level: number };
+
+/** Make useGameStore(selector) read from a fixed mock state. */
+const setStore = (partial: Partial<StorePart>) => {
+  const state: StorePart = { gameId: null, name: "", score: 0, level: 1, ...partial };
+  mockedUseGameStore.mockImplementation((selector: (s: StorePart) => unknown) => selector(state));
+};
+
+/** Build a server top-N list (already ranked, newest-ish created_at by index). */
+const serverRows = (
+  rows: Array<{ id: string; name: string; score: number; level?: number }>
+): HighscoreRow[] =>
+  rows.map((r, i) => ({
+    id: r.id,
+    name: r.name,
+    score: r.score,
+    level: r.level ?? 1,
+    created_at: `2026-01-${String(i + 1).padStart(2, "0")}T00:00:00.000Z`,
+    rank: i + 1,
+  }));
+
+describe("Leaderboard optimistic merge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setStore({}); // no game in progress by default
+  });
+
+  it("renders the server list and highlights no one when the store is empty", () => {
+    render(
+      <Leaderboard
+        initial={serverRows([
+          { id: "a", name: "Ada", score: 100 },
+          { id: "b", name: "Bob", score: 50 },
+        ])}
+      />
+    );
+
+    expect(screen.getByText("Ada")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.queryByText("You")).not.toBeInTheDocument();
+  });
+
+  it("optimistically inserts the player's just-finished score in the correct position", () => {
+    setStore({ gameId: "me", name: "Mia", score: 80, level: 4 });
+
+    render(
+      <Leaderboard
+        initial={serverRows([
+          { id: "a", name: "Ada", score: 100 },
+          { id: "b", name: "Bob", score: 50 },
+        ])}
+      />
+    );
+
+    // Mia (80) lands between Ada (100) and Bob (50) and is flagged "You".
+    expect(screen.getByText("Mia")).toBeInTheDocument();
+    expect(screen.getByText("You")).toBeInTheDocument();
+
+    const ranks = screen
+      .getAllByText(/^(Ada|Mia|Bob)$/)
+      .map((el) => el.textContent);
+    expect(ranks).toEqual(["Ada", "Mia", "Bob"]);
+  });
+
+  it("does not duplicate the player when the server list already includes them", () => {
+    setStore({ gameId: "me", name: "Mia", score: 80, level: 4 });
+
+    render(
+      <Leaderboard
+        initial={serverRows([
+          { id: "a", name: "Ada", score: 100 },
+          { id: "me", name: "Mia", score: 80 },
+        ])}
+      />
+    );
+
+    expect(screen.getAllByText("Mia")).toHaveLength(1);
+    expect(screen.getByText("You")).toBeInTheDocument(); // existing row still highlighted
+  });
+
+  it("does not highlight when the player's score does not make the top 10", () => {
+    const ten = Array.from({ length: 10 }, (_, i) => ({
+      id: `r${i}`,
+      name: `Player${i}`,
+      score: 100,
+    }));
+    setStore({ gameId: "me", name: "Loser", score: 5, level: 1 });
+
+    render(<Leaderboard initial={serverRows(ten)} />);
+
+    expect(screen.queryByText("Loser")).not.toBeInTheDocument();
+    expect(screen.queryByText("You")).not.toBeInTheDocument();
+  });
+
+  it("ignores a zero score (nothing scored yet)", () => {
+    setStore({ gameId: "me", name: "Mia", score: 0 });
+
+    render(<Leaderboard initial={serverRows([{ id: "a", name: "Ada", score: 100 }])} />);
+
+    expect(screen.queryByText("Mia")).not.toBeInTheDocument();
+    expect(screen.queryByText("You")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why

`/highscores` was `force-dynamic` — re-rendered from scratch and re-queried the DB live on **every** request (~2.5s TTFB measured in prod, vs <500ms for every other route). Under cold starts that can exceed the function timeout and surface as **intermittent unavailability** — which is invisible to Supabase logs (the query itself succeeds in 0.056ms) and to Sentry (a timeout isn't an exception). That matches the "sometimes unavailable" reports.

## What

- **ISR**: `force-dynamic` → `export const revalidate = 30`. The leaderboard is pre-rendered and served from cache; a DB hiccup now serves the last good page instead of erroring (strictly more resilient than rendering live each request).
- **Optimistic player row**: extracted the table into a client `<Leaderboard>` that merges the player's just-finished score (from the game store) into the cached top-10 — so a fresh high score shows up **immediately**, before the 30s cache refreshes. Deduped by game id, trimmed to top 10, flagged **"You"**. Self-correcting once the cache catches up.
- **Tests**: `leaderboard.test.tsx` covers insert/position, dedupe, top-10 trimming, and the zero-score case.

## Verification

- `yarn type-check` clean · `yarn lint` clean · **96/96 tests pass**

## Deploy note

ISR prerenders `/highscores` at **build time**, so the build needs the Supabase env vars (present on Vercel) and the DB reachable during build. After deploy, `/highscores` shifts from a `λ` function to a `●` static/ISR route. No schema or env changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Leaderboard now displays with improved performance and real-time score optimization, ensuring your scores appear immediately upon submission.

* **Documentation**
  * Added guide explaining intermittent app availability, system health status, and recommended actions to enhance reliability and leaderboard refresh times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riethmayer/eureka/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->