### PR TITLE
chore: env sample + harden /highscores against fetch failures

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -1,5 +1,31 @@
-# Copy this file to .env.local and fill in the values.
-# These are the publishable/anon keys — safe to share.
+# ─────────────────────────────────────────────────────────────────────────────
+# Eureka — environment variables
+#
+# Local dev:   copy this file to `.env.local` and fill in the values below.
+# Prod/Preview: configured in Vercel (Project → Settings → Environment Variables).
+#
+# PUBLIC values are safe to commit/share: every NEXT_PUBLIC_* var ships in the
+# browser bundle, and the Supabase key here is the *publishable* key, gated by
+# Row-Level Security. SECRET values must never be committed (they're gitignored
+# via `.env.local`).
+# ─────────────────────────────────────────────────────────────────────────────
 
-NEXT_PUBLIC_SUPABASE_URL="https://<project-ref>.supabase.co"
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="sb_publishable_..."
+# ── Public · required for local dev ──────────────────────────────────────────
+# The app talks to Supabase over its REST API using these two.
+NEXT_PUBLIC_SUPABASE_URL="https://lthqyqlislwikgoxmttn.supabase.co"
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY="sb_publishable_EWJzsZk_xRhq9vodH4cc7Q_1w0yTBSr"
+
+# ── Public · optional ─────────────────────────────────────────────────────────
+# Sentry error monitoring. If unset, Sentry just stays disabled locally (fine for
+# most local work). The DSN is a public value — copy it from
+# Sentry → Project Settings → Client Keys (DSN).
+# NEXT_PUBLIC_SENTRY_DSN="https://<key>@<org>.ingest.sentry.io/<project-id>"
+#
+# Server/edge runtimes fall back to NEXT_PUBLIC_SENTRY_DSN; only set this to
+# point them at a different Sentry project.
+# SENTRY_DSN=""
+
+# ── Secret · NOT needed for local dev (CI / Vercel build only) ────────────────
+# Used by `next build` to upload source maps to Sentry. Leave unset locally.
+# Create one at Sentry → Settings → Auth Tokens. NEVER commit a real value.
+# SENTRY_AUTH_TOKEN=""

--- a/src/app/highscores/page.tsx
+++ b/src/app/highscores/page.tsx
@@ -9,7 +9,17 @@ import Leaderboard from "@/components/leaderboard";
 export const revalidate = 30;
 
 const HighscoresController = async () => {
-  const highscores = await getHighscores();
+  // Never let a leaderboard fetch failure crash the build or the request: a
+  // preview build without Supabase env, or a transient DB blip, would otherwise
+  // fail prerendering and break the whole deploy. Fall back to an empty board;
+  // ISR refills it on the next successful revalidation, and the client
+  // <Leaderboard> still shows the player their own just-finished score.
+  let highscores: Awaited<ReturnType<typeof getHighscores>> = [];
+  try {
+    highscores = await getHighscores();
+  } catch (error) {
+    console.error("Failed to load highscores:", error);
+  }
 
   return (
     <div className="flex flex-col items-center px-2 sm:px-4 pt-6 sm:pt-8 pb-4 h-full">


### PR DESCRIPTION
Follow-up to #43 (highscores ISR). Two small, deploy-resilience + DX changes.

## 1. Harden `/highscores` against fetch failures
Since #43 the page prerenders at **build time** (ISR), which coupled deploys to Supabase env + DB reachability — a preview build without the `NEXT_PUBLIC_SUPABASE_*` vars failed prerendering and broke the build (we saw exactly this on #43's preview deploy). Now `getHighscores()` is wrapped in try/catch: on failure the page renders an **empty board** and logs the error, instead of crashing the prerender. ISR refills it on the next successful revalidation, and the client `<Leaderboard>` still shows the player their own just-finished score.

## 2. Expand `.env.development.sample`
Documents the full env surface: public Supabase values filled in (they ship in the client bundle anyway / are RLS-gated publishable keys), Sentry DSN + `SENTRY_AUTH_TOKEN` as optional/secret placeholders with notes on where to get them. Copy to `.env.local` for local dev.

## Note
The third item discussed (remove `/sentry-test`) was **already done in #40** — nothing to do here.

## Verification
`yarn type-check` clean · `yarn lint` clean · **96/96 tests pass**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of the highscores page by gracefully handling data fetch failures, ensuring the leaderboard displays with available data instead of encountering errors during page load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riethmayer/eureka/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->