### PR TITLE
Fix hydration mismatch in the dev strategy switcher

### DIFF
--- a/src/components/strategy-switcher/index.tsx
+++ b/src/components/strategy-switcher/index.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useSyncExternalStore } from "react";
 import { useGameStore } from "@/zustand/game-store";
 import {
+  DEFAULT_STRATEGY,
   getOrderStrategy,
   listOrderStrategies,
   setOrderStrategy,
+  subscribeOrderStrategy,
 } from "@/utils/order-strategies";
 
 /**
@@ -18,8 +20,13 @@ const enabled = process.env.NODE_ENV !== "production";
 
 const StrategySwitcher: React.FC = () => {
   const redeal = useGameStore((state) => state.redealCurrentLevel);
-  const [current, setCurrent] = useState<string>(() =>
-    enabled ? getOrderStrategy().name : ""
+  // Hydration-safe read of the active strategy: SSR + first client render use the
+  // build-time default; after hydration the client snapshot resolves localStorage.
+  // Re-renders when setOrderStrategy fires (e.g. cycling).
+  const current = useSyncExternalStore(
+    subscribeOrderStrategy,
+    () => getOrderStrategy().name,
+    () => DEFAULT_STRATEGY
   );
 
   const cycle = useCallback(
@@ -28,7 +35,6 @@ const StrategySwitcher: React.FC = () => {
       const idx = names.indexOf(getOrderStrategy().name);
       const next = names[(idx + dir + names.length) % names.length];
       setOrderStrategy(next);
-      setCurrent(next);
       redeal();
     },
     [redeal]

--- a/src/utils/order-strategies.ts
+++ b/src/utils/order-strategies.ts
@@ -199,6 +199,17 @@ export const listOrderStrategies = (): Array<{ name: string; description: string
 const DEV = process.env.NODE_ENV !== "production";
 
 let runtimeOverride: string | null = null;
+const strategyListeners = new Set<() => void>();
+
+/** Subscribe to active-strategy changes. Returns an unsubscribe fn.
+ *  Lets the dev switcher reflect the strategy via React's useSyncExternalStore
+ *  (hydration-safe: server snapshot = DEFAULT, client snapshot = resolved). */
+export const subscribeOrderStrategy = (cb: () => void): (() => void) => {
+  strategyListeners.add(cb);
+  return () => {
+    strategyListeners.delete(cb);
+  };
+};
 
 /**
  * Override the active strategy for this session. Pass a name from `STRATEGIES`,
@@ -215,6 +226,7 @@ export const setOrderStrategy = (name: string | null): void => {
   } catch {
     /* localStorage unavailable (SSR / privacy mode) — in-memory override still applies */
   }
+  strategyListeners.forEach((cb) => cb());
 };
 
 /**


### PR DESCRIPTION
On `/play` in dev, React reported a hydration mismatch in `StrategySwitcher` ("the server rendered text didn't match the client … this tree will be regenerated"), which is also why the strategy badge/selection wasn't showing reliably.

**Cause:** `current` was initialised from `getOrderStrategy()` *during render*. That reads `localStorage` (the persisted strategy override), which exists on the client but not during SSR — so the highlighted `<li>` differed between the server and client HTML.

**Fix:** read the active strategy with `useSyncExternalStore`:
- server snapshot = the build-time `DEFAULT_STRATEGY` (so SSR and the first client render agree → no mismatch),
- client snapshot = `getOrderStrategy().name` (resolves the localStorage override after hydration),
- new `subscribeOrderStrategy` (notified by `setOrderStrategy`) re-renders the badge when cycling.

Dev-only component — no production behaviour change. Verified locally: switcher renders cleanly with the default *and* with a `localStorage` override (the case that previously mismatched), no error overlay. `lint` / `type-check` / `vitest` (106) / `build` green.

Not merged — opening for review.